### PR TITLE
Add Test Voices feature to admin UI

### DIFF
--- a/tts-proxy/admin-ui/src/components/AppLayout.vue
+++ b/tts-proxy/admin-ui/src/components/AppLayout.vue
@@ -47,6 +47,13 @@ function handleLogout() {
                                 Engines
                             </router-link>
                             <router-link
+                                to="/test-voices"
+                                class="text-gray-600 hover:text-gray-900 transition-colors"
+                                active-class="text-blue-600 font-medium"
+                            >
+                                Test Voices
+                            </router-link>
+                            <router-link
                                 to="/settings"
                                 class="text-gray-600 hover:text-gray-900 transition-colors"
                                 active-class="text-blue-600 font-medium"

--- a/tts-proxy/admin-ui/src/router/index.ts
+++ b/tts-proxy/admin-ui/src/router/index.ts
@@ -24,6 +24,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: "/test-voices",
+    name: "test-voices",
+    component: () => import("@/views/TestVoicesView.vue"),
+    meta: { requiresAuth: true },
+  },
+  {
     path: "/settings",
     name: "settings",
     component: () => import("@/views/SettingsView.vue"),

--- a/tts-proxy/admin-ui/src/stores/voices.ts
+++ b/tts-proxy/admin-ui/src/stores/voices.ts
@@ -1,0 +1,161 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './auth'
+import type { Voice, VoicesResponse, VoiceSettings } from '@/types'
+
+export const useVoicesStore = defineStore('voices', () => {
+  const authStore = useAuthStore()
+
+  // State
+  const voices = ref<Voice[]>([])
+  const selectedVoice = ref<Voice | null>(null)
+  const isLoading = ref(false)
+  const isSynthesizing = ref(false)
+  const error = ref<string | null>(null)
+  const lastFetched = ref<string | null>(null)
+
+  // Filter state
+  const engineFilter = ref<string>('')
+  const languageFilter = ref<string>('')
+  const genderFilter = ref<string>('')
+  const searchQuery = ref('')
+
+  // Computed
+  const availableEngines = computed(() => {
+    const engines = new Set(voices.value.map(v => v.labels.engine))
+    return Array.from(engines).sort()
+  })
+
+  const availableLanguages = computed(() => {
+    const languages = new Set(voices.value.map(v => v.labels.language).filter(Boolean))
+    return Array.from(languages).sort()
+  })
+
+  const filteredVoices = computed(() => {
+    return voices.value.filter(voice => {
+      // Engine filter
+      if (engineFilter.value && voice.labels.engine !== engineFilter.value) {
+        return false
+      }
+
+      // Language filter
+      if (languageFilter.value && voice.labels.language !== languageFilter.value) {
+        return false
+      }
+
+      // Gender filter
+      if (genderFilter.value && voice.labels.gender !== genderFilter.value) {
+        return false
+      }
+
+      // Search query
+      if (searchQuery.value) {
+        const query = searchQuery.value.toLowerCase()
+        return (
+          voice.name.toLowerCase().includes(query) ||
+          voice.description.toLowerCase().includes(query) ||
+          voice.labels.engine.toLowerCase().includes(query) ||
+          (voice.labels.language?.toLowerCase().includes(query) ?? false)
+        )
+      }
+
+      return true
+    })
+  })
+
+  // Actions
+  async function fetchVoices(): Promise<void> {
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const response = await fetch('/v1/voices', {
+        headers: authStore.getHeaders()
+      })
+
+      if (response.ok) {
+        const data: VoicesResponse = await response.json()
+        voices.value = data.voices
+        lastFetched.value = new Date().toISOString()
+      } else {
+        error.value = 'Failed to fetch voices'
+      }
+    } catch (e) {
+      error.value = 'Connection error while fetching voices'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function synthesize(
+    voiceId: string,
+    text: string,
+    settings?: VoiceSettings
+  ): Promise<Blob> {
+    isSynthesizing.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(`/v1/text-to-speech/${encodeURIComponent(voiceId)}`, {
+        method: 'POST',
+        headers: {
+          ...authStore.getHeaders(),
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          text,
+          voice_settings: settings,
+          output_format: 'mp3_44100_128'
+        })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null)
+        throw new Error(errorData?.error?.message || `Synthesis failed: ${response.status}`)
+      }
+
+      return await response.blob()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Synthesis failed'
+      error.value = message
+      throw e
+    } finally {
+      isSynthesizing.value = false
+    }
+  }
+
+  function selectVoice(voice: Voice | null): void {
+    selectedVoice.value = voice
+  }
+
+  function clearFilters(): void {
+    engineFilter.value = ''
+    languageFilter.value = ''
+    genderFilter.value = ''
+    searchQuery.value = ''
+  }
+
+  return {
+    // State
+    voices,
+    selectedVoice,
+    isLoading,
+    isSynthesizing,
+    error,
+    lastFetched,
+    // Filters
+    engineFilter,
+    languageFilter,
+    genderFilter,
+    searchQuery,
+    // Computed
+    availableEngines,
+    availableLanguages,
+    filteredVoices,
+    // Actions
+    fetchVoices,
+    synthesize,
+    selectVoice,
+    clearFilters,
+  }
+})

--- a/tts-proxy/admin-ui/src/types/index.ts
+++ b/tts-proxy/admin-ui/src/types/index.ts
@@ -82,3 +82,46 @@ export interface User {
   isAdmin: boolean
 }
 
+// Voice types (ElevenLabs-compatible format from backend)
+export interface Voice {
+  voice_id: string
+  name: string
+  samples: null
+  category: string // engine name
+  fine_tuning: {
+    is_allowed_to_fine_tune: boolean
+    state: Record<string, unknown>
+  }
+  labels: {
+    engine: string
+    language: string
+    gender?: string
+    [key: string]: string | undefined
+  }
+  description: string
+  preview_url: string | null
+  available_for_tiers: string[]
+  settings: null
+  sharing: null
+  high_quality_base_model_ids: string[]
+}
+
+export interface VoicesResponse {
+  voices: Voice[]
+}
+
+export interface VoiceSettings {
+  stability?: number
+  similarity_boost?: number
+  style?: number
+  use_speaker_boost?: boolean
+  speed?: number
+  pitch?: number
+}
+
+export interface SynthesizeRequest {
+  text: string
+  voice_settings?: VoiceSettings
+  output_format?: string
+}
+

--- a/tts-proxy/admin-ui/src/views/TestVoicesView.vue
+++ b/tts-proxy/admin-ui/src/views/TestVoicesView.vue
@@ -1,0 +1,426 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import AppLayout from '@/components/AppLayout.vue'
+import { useVoicesStore } from '@/stores/voices'
+import type { Voice, VoiceSettings } from '@/types'
+
+const voicesStore = useVoicesStore()
+
+// Test panel state
+const testText = ref('Hello, this is a test of the text-to-speech system.')
+const voiceSettings = ref<VoiceSettings>({
+  speed: 1.0,
+  pitch: 0
+})
+
+// Audio state
+const audioUrl = ref<string | null>(null)
+const audioElement = ref<HTMLAudioElement | null>(null)
+const isPlaying = ref(false)
+const audioDuration = ref(0)
+const audioCurrentTime = ref(0)
+
+// Character count
+const maxChars = 1000
+const charCount = ref(testText.value.length)
+
+watch(testText, (newText) => {
+  charCount.value = newText.length
+})
+
+onMounted(() => {
+  voicesStore.fetchVoices()
+})
+
+function selectVoice(voice: Voice) {
+  voicesStore.selectVoice(voice)
+  // Clear previous audio when selecting new voice
+  clearAudio()
+}
+
+function clearAudio() {
+  if (audioUrl.value) {
+    URL.revokeObjectURL(audioUrl.value)
+    audioUrl.value = null
+  }
+  isPlaying.value = false
+  audioDuration.value = 0
+  audioCurrentTime.value = 0
+}
+
+async function playSpeech() {
+  if (!voicesStore.selectedVoice || !testText.value.trim()) return
+
+  clearAudio()
+
+  try {
+    const blob = await voicesStore.synthesize(
+      voicesStore.selectedVoice.voice_id,
+      testText.value,
+      voiceSettings.value
+    )
+
+    audioUrl.value = URL.createObjectURL(blob)
+
+    // Set up audio element for duration tracking
+    const audio = new Audio(audioUrl.value)
+    audio.addEventListener('loadedmetadata', () => {
+      audioDuration.value = audio.duration
+    })
+    audio.addEventListener('timeupdate', () => {
+      audioCurrentTime.value = audio.currentTime
+    })
+    audio.addEventListener('ended', () => {
+      isPlaying.value = false
+      audioCurrentTime.value = 0
+    })
+    audioElement.value = audio
+
+    // Auto-play immediately
+    audio.play()
+      .then(() => {
+        isPlaying.value = true
+      })
+      .catch((err) => {
+        console.error('Error playing audio:', err)
+      })
+  } catch (e) {
+    // Error is handled in store
+  }
+}
+
+function playAudio() {
+  if (!audioElement.value) return
+
+  audioElement.value.play()
+    .then(() => {
+      isPlaying.value = true
+    })
+    .catch((err) => {
+      console.error('Error playing audio:', err)
+      alert(`Failed to play audio: ${err.message}. Try clicking anywhere on the page first.`)
+    })
+}
+
+function pauseAudio() {
+  if (!audioElement.value) return
+  audioElement.value.pause()
+  isPlaying.value = false
+}
+
+function downloadAudio() {
+  if (!audioUrl.value || !voicesStore.selectedVoice) return
+
+  const a = document.createElement('a')
+  a.href = audioUrl.value
+  a.download = `${voicesStore.selectedVoice.name.replace(/\s+/g, '-')}-test.mp3`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+function getGenderBadgeClass(gender: string | undefined): string {
+  switch (gender?.toLowerCase()) {
+    case 'male':
+      return 'bg-blue-100 text-blue-800'
+    case 'female':
+      return 'bg-pink-100 text-pink-800'
+    default:
+      return 'bg-gray-100 text-gray-800'
+  }
+}
+</script>
+
+<template>
+  <AppLayout>
+    <div class="space-y-6">
+      <!-- Header -->
+      <div class="flex justify-between items-center">
+        <h2 class="text-2xl font-bold text-gray-900">Test Voices</h2>
+        <button
+          @click="voicesStore.fetchVoices()"
+          :disabled="voicesStore.isLoading"
+          class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
+        >
+          {{ voicesStore.isLoading ? 'Loading...' : 'Refresh' }}
+        </button>
+      </div>
+
+      <p v-if="voicesStore.lastFetched" class="text-sm text-gray-500">
+        Last updated: {{ new Date(voicesStore.lastFetched).toLocaleString() }}
+      </p>
+
+      <!-- Filters -->
+      <div class="bg-white rounded-lg shadow p-4">
+        <div class="flex flex-wrap gap-4 items-center">
+          <!-- Engine Filter -->
+          <div class="flex-1 min-w-[150px]">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Engine</label>
+            <select
+              v-model="voicesStore.engineFilter"
+              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">All Engines</option>
+              <option v-for="engine in voicesStore.availableEngines" :key="engine" :value="engine">
+                {{ engine }}
+              </option>
+            </select>
+          </div>
+
+          <!-- Language Filter -->
+          <div class="flex-1 min-w-[150px]">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Language</label>
+            <select
+              v-model="voicesStore.languageFilter"
+              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">All Languages</option>
+              <option v-for="lang in voicesStore.availableLanguages" :key="lang" :value="lang">
+                {{ lang }}
+              </option>
+            </select>
+          </div>
+
+          <!-- Gender Filter -->
+          <div class="flex-1 min-w-[150px]">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Gender</label>
+            <select
+              v-model="voicesStore.genderFilter"
+              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">All</option>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+              <option value="neutral">Neutral</option>
+            </select>
+          </div>
+
+          <!-- Search -->
+          <div class="flex-[2] min-w-[200px]">
+            <label class="block text-sm font-medium text-gray-700 mb-1">Search</label>
+            <input
+              v-model="voicesStore.searchQuery"
+              type="text"
+              placeholder="Search voices..."
+              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+
+          <!-- Clear Filters -->
+          <div class="self-end">
+            <button
+              @click="voicesStore.clearFilters()"
+              class="px-4 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Loading State -->
+      <div v-if="voicesStore.isLoading" class="text-center py-12">
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <p class="mt-2 text-gray-600">Loading voices...</p>
+      </div>
+
+      <!-- Error State -->
+      <div v-else-if="voicesStore.error" class="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+        {{ voicesStore.error }}
+      </div>
+
+      <!-- No Voices -->
+      <div v-else-if="voicesStore.voices.length === 0" class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
+        <h3 class="font-medium text-yellow-800">No voices available</h3>
+        <p class="mt-2 text-yellow-700">
+          Configure TTS engines in the Engines page to enable voice synthesis.
+        </p>
+      </div>
+
+      <!-- Main Content -->
+      <div v-else class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Voice List -->
+        <div class="lg:col-span-2 space-y-4">
+          <div class="text-sm text-gray-500 mb-2">
+            Showing {{ voicesStore.filteredVoices.length }} of {{ voicesStore.voices.length }} voices
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-[600px] overflow-y-auto p-1">
+            <div
+              v-for="voice in voicesStore.filteredVoices"
+              :key="voice.voice_id"
+              @click="selectVoice(voice)"
+              :class="[
+                'bg-white rounded-lg shadow p-4 cursor-pointer transition-all hover:shadow-md',
+                voicesStore.selectedVoice?.voice_id === voice.voice_id
+                  ? 'ring-2 ring-blue-500 bg-blue-50'
+                  : 'hover:bg-gray-50'
+              ]"
+            >
+              <div class="flex justify-between items-start mb-2">
+                <h3 class="font-semibold text-gray-900 truncate" :title="voice.name">
+                  {{ voice.name }}
+                </h3>
+                <span
+                  class="text-xs px-2 py-0.5 rounded font-medium whitespace-nowrap ml-2"
+                  :class="getGenderBadgeClass(voice.labels.gender)"
+                >
+                  {{ voice.labels.gender || 'Unknown' }}
+                </span>
+              </div>
+              <div class="space-y-1 text-sm">
+                <div class="flex items-center gap-2">
+                  <span class="text-gray-500">Engine:</span>
+                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-700 rounded">
+                    {{ voice.labels.engine }}
+                  </span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-gray-500">Language:</span>
+                  <span class="text-gray-700">{{ voice.labels.language || 'Unknown' }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Test Panel -->
+        <div class="lg:col-span-1">
+          <div class="bg-white rounded-lg shadow p-6 sticky top-4">
+            <h3 class="text-lg font-semibold text-gray-900 mb-4">Test Panel</h3>
+
+            <div v-if="!voicesStore.selectedVoice" class="text-center py-8 text-gray-500">
+              Select a voice from the list to test it
+            </div>
+
+            <div v-else class="space-y-4">
+              <!-- Selected Voice Info -->
+              <div class="bg-blue-50 rounded-lg p-3">
+                <div class="font-medium text-blue-900">{{ voicesStore.selectedVoice.name }}</div>
+                <div class="text-sm text-blue-700">
+                  {{ voicesStore.selectedVoice.labels.engine }} - {{ voicesStore.selectedVoice.labels.language }}
+                </div>
+              </div>
+
+              <!-- Text Input -->
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  Text to synthesize
+                </label>
+                <textarea
+                  v-model="testText"
+                  rows="4"
+                  :maxlength="maxChars"
+                  class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 resize-none"
+                  placeholder="Enter text to synthesize..."
+                ></textarea>
+                <div class="text-xs text-gray-500 text-right mt-1">
+                  {{ charCount }} / {{ maxChars }}
+                </div>
+              </div>
+
+              <!-- Voice Settings -->
+              <div class="space-y-3">
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 mb-1">
+                    Speed: {{ voiceSettings.speed?.toFixed(1) }}
+                  </label>
+                  <input
+                    v-model.number="voiceSettings.speed"
+                    type="range"
+                    min="0.5"
+                    max="2"
+                    step="0.1"
+                    class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-gray-700 mb-1">
+                    Pitch: {{ voiceSettings.pitch }}
+                  </label>
+                  <input
+                    v-model.number="voiceSettings.pitch"
+                    type="range"
+                    min="-10"
+                    max="10"
+                    step="1"
+                    class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  />
+                </div>
+              </div>
+
+              <!-- Play Button -->
+              <button
+                @click="playSpeech"
+                :disabled="voicesStore.isSynthesizing || !testText.trim()"
+                class="w-full px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                <svg v-if="!voicesStore.isSynthesizing" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z" />
+                </svg>
+                {{ voicesStore.isSynthesizing ? 'Loading...' : 'Play' }}
+              </button>
+
+              <!-- Audio Player -->
+              <div v-if="audioUrl" class="space-y-3">
+                <div class="bg-gray-100 rounded-lg p-3">
+                  <div class="flex items-center gap-3">
+                    <button
+                      v-if="!isPlaying"
+                      @click="playAudio"
+                      class="w-8 h-8 flex items-center justify-center bg-green-600 hover:bg-green-700 text-white rounded-full transition-colors"
+                    >
+                      <svg class="w-4 h-4 ml-0.5" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z" />
+                      </svg>
+                    </button>
+                    <button
+                      v-else
+                      @click="pauseAudio"
+                      class="w-8 h-8 flex items-center justify-center bg-yellow-600 hover:bg-yellow-700 text-white rounded-full transition-colors"
+                    >
+                      <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
+                      </svg>
+                    </button>
+                    <div class="flex-1">
+                      <div class="h-1.5 bg-gray-300 rounded-full overflow-hidden">
+                        <div
+                          class="h-full bg-green-600 transition-all"
+                          :style="{ width: audioDuration ? `${(audioCurrentTime / audioDuration) * 100}%` : '0%' }"
+                        ></div>
+                      </div>
+                    </div>
+                    <span class="text-xs text-gray-500 font-mono">
+                      {{ formatTime(audioCurrentTime) }}
+                    </span>
+                    <button
+                      @click="downloadAudio"
+                      class="w-8 h-8 flex items-center justify-center text-gray-600 hover:text-gray-900 hover:bg-gray-200 rounded-full transition-colors"
+                      title="Download"
+                    >
+                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Synthesis Error -->
+              <div v-if="voicesStore.error" class="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                {{ voicesStore.error }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>

--- a/tts-proxy/public/admin/index.html
+++ b/tts-proxy/public/admin/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/admin/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenVoiceProxy Admin</title>
-    <script type="module" crossorigin src="/admin/assets/index-C4O05_Js.js"></script>
-    <link rel="stylesheet" crossorigin href="/admin/assets/index-Dg-TvT_e.css">
+    <script type="module" crossorigin src="/admin/assets/index-xAujA8e9.js"></script>
+    <link rel="stylesheet" crossorigin href="/admin/assets/index-0-uZN4rU.css">
   </head>
   <body>
     <div id="app"></div>

--- a/tts-proxy/src/infrastructure/http/server.ts
+++ b/tts-proxy/src/infrastructure/http/server.ts
@@ -91,6 +91,7 @@ export function createServer(
         scriptSrc: ["'self'", "'unsafe-inline'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", 'data:', 'blob:'],
+        mediaSrc: ["'self'", 'blob:'],
         connectSrc: ["'self'", 'ws:', 'wss:'],
       },
     })


### PR DESCRIPTION
## Summary
- Add a new **Test Voices** page to the admin UI at `/admin/test-voices`
- Browse all available voices from configured TTS engines
- Filter voices by engine, language, gender, and search query
- Select a voice, enter text, and play synthesized speech directly in the browser
- Download generated audio files

## Changes
- `tts-proxy/admin-ui/src/views/TestVoicesView.vue` - New test voices view
- `tts-proxy/admin-ui/src/stores/voices.ts` - Pinia store for voice management
- `tts-proxy/admin-ui/src/types/index.ts` - Added Voice types
- `tts-proxy/admin-ui/src/router/index.ts` - Added /test-voices route
- `tts-proxy/admin-ui/src/components/AppLayout.vue` - Added nav link
- `tts-proxy/src/infrastructure/http/server.ts` - Updated CSP to allow blob: URLs for audio

## Test plan
- [ ] Navigate to /admin/test-voices
- [ ] Verify voices load from configured engines
- [ ] Test filtering by engine, language, gender
- [ ] Select a voice and enter text
- [ ] Click Play and verify audio plays in browser
- [ ] Test download functionality